### PR TITLE
Add bonds to render, support two letter atoms and special names

### DIFF
--- a/ChemBox/Assets/Cylinder.prefab
+++ b/ChemBox/Assets/Cylinder.prefab
@@ -28,7 +28,7 @@ Transform:
   m_GameObject: {fileID: 7833149507352379630}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 0.3, y: 0.75, z: 0.3}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}

--- a/ChemBox/Assets/Scenes/SampleScene.unity
+++ b/ChemBox/Assets/Scenes/SampleScene.unity
@@ -384,9 +384,12 @@ MonoBehaviour:
   parent: {fileID: 1449099377}
   sphere: {fileID: 7364276820153522626, guid: ccf7f8733342ccf44b11192f3eee8f8e, type: 3}
   dummy: {fileID: 9071060762828834, guid: 2bf1bfe5600da4243abf5a25bd261db2, type: 3}
-  bond: {fileID: 7833149507352379630, guid: 37b995be4910ebd448298cde1a93ad83, type: 3}
+  SingleBond: {fileID: 7833149507352379630, guid: 37b995be4910ebd448298cde1a93ad83, type: 3}
+  DoubleBond: {fileID: 7833149507352379630, guid: 37b995be4910ebd448298cde1a93ad83, type: 3}
+  TripleBond: {fileID: 7833149507352379630, guid: 37b995be4910ebd448298cde1a93ad83, type: 3}
   opsin: {fileID: 1449099378}
-  molname: '3-hexanone '
+  bonds: 1
+  molname: strontium acetate
 --- !u!4 &1449099377
 Transform:
   m_ObjectHideFlags: 0

--- a/ChemBox/Assets/Scripts/GenerateMolecule.cs.meta
+++ b/ChemBox/Assets/Scripts/GenerateMolecule.cs.meta
@@ -3,7 +3,14 @@ guid: 25482cb0a030421438d327d197df1103
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2
-  defaultReferences: []
+  defaultReferences:
+  - parent: {instanceID: 0}
+  - sphere: {fileID: 7364276820153522626, guid: ccf7f8733342ccf44b11192f3eee8f8e, type: 3}
+  - dummy: {fileID: 9071060762828834, guid: 2bf1bfe5600da4243abf5a25bd261db2, type: 3}
+  - SingleBond: {fileID: 7833149507352379630, guid: 37b995be4910ebd448298cde1a93ad83, type: 3}
+  - DoubleBond: {instanceID: 0}
+  - TripleBond: {instanceID: 0}
+  - opsin: {instanceID: 0}
   executionOrder: 0
   icon: {instanceID: 0}
   userData: 


### PR DESCRIPTION
Previously, it was assumed that each atom was only one letter long, and
any special attributes included were discarded...
Bond rendering toggle also included